### PR TITLE
Add configurable affiliate CTA placements with analytics tracking

### DIFF
--- a/content/docs/comparisons/vs-copilot.mdx
+++ b/content/docs/comparisons/vs-copilot.mdx
@@ -1,6 +1,23 @@
 ---
 title: Claude Code vs GitHub Copilot
 description: "Inline autocomplete vs agentic coding. They solve fundamentally different problems."
+targetKeyword: "claude code vs github copilot"
+comparisonEntities:
+  - "Claude Code"
+  - "GitHub Copilot"
+relatedLinks:
+  - title: "Claude Code vs Cursor"
+    href: "/docs/comparisons/vs-cursor"
+    description: "Compare terminal-agent workflows with editor-native AI assistance."
+  - title: "Claude Code vs OpenAI Codex"
+    href: "/docs/comparisons/vs-codex"
+    description: "Understand local execution versus remote sandbox tradeoffs."
+  - title: "Claude Pro vs Max vs API"
+    href: "/docs/comparisons/pro-vs-max"
+    description: "Map Copilot migration plans to the right Claude budget tier."
+  - title: "Team Adoption Workflow"
+    href: "/docs/workflows/team-adoption"
+    description: "Use a rollout checklist to move teams from pilot to production safely."
 ---
 
 This is not really an apples-to-apples comparison. GitHub Copilot is an autocomplete engine. Claude Code is an autonomous coding agent. They do fundamentally different things, and honestly, many developers use both.

--- a/content/docs/comparisons/vs-cursor.mdx
+++ b/content/docs/comparisons/vs-cursor.mdx
@@ -1,6 +1,23 @@
 ---
 title: Claude Code vs Cursor
 description: "They're not the same thing. Not even close. Here's the real difference and how to pick the right one."
+targetKeyword: "claude code vs cursor"
+comparisonEntities:
+  - "Claude Code"
+  - "Cursor"
+relatedLinks:
+  - title: "Claude Code vs GitHub Copilot"
+    href: "/docs/comparisons/vs-copilot"
+    description: "See how agentic workflows compare against autocomplete-first tooling."
+  - title: "Claude Code vs OpenAI Codex"
+    href: "/docs/comparisons/vs-codex"
+    description: "Review local terminal workflows versus cloud-sandbox execution."
+  - title: "Claude Pro vs Max vs API"
+    href: "/docs/comparisons/pro-vs-max"
+    description: "Pick the right Claude plan before rolling the tool out across a team."
+  - title: "Which Claude Interface Should You Use?"
+    href: "/docs/foundations/which-interface"
+    description: "Clarify when terminal, desktop, and web interfaces fit your workflow."
 ---
 
 ## They're Solving Different Problems

--- a/src/app/(home)/guide/page.tsx
+++ b/src/app/(home)/guide/page.tsx
@@ -10,9 +10,15 @@ import { CopyBlock } from '@/components/guide/copy-block';
 import { Collapsible } from '@/components/guide/collapsible';
 import { Checkpoint } from '@/components/guide/checkpoint';
 import { DemoCard } from '@/components/demo-card';
+import { AffiliateCTA } from '@/components/affiliate-cta';
+import { getAffiliateCtasForPage } from '@/lib/affiliate-cta-config';
 
 export default function GuidePage() {
   const progress = useGuideProgress();
+  const ctas = getAffiliateCtasForPage('guide');
+  const inlineCta = ctas.find((cta) => cta.placement === 'inline');
+  const midBannerCta = ctas.find((cta) => cta.placement === 'mid-banner');
+  const endCardCta = ctas.find((cta) => cta.placement === 'end-card');
 
   if (!progress.loaded) {
     return (
@@ -68,6 +74,7 @@ export default function GuidePage() {
 
       {/* Guide Content */}
       <main className="mx-auto max-w-3xl space-y-16 px-6 pb-24">
+        {inlineCta ? <AffiliateCTA {...inlineCta} /> : null}
 
         {/* ═══════════ PHASE 1: Getting Started ═══════════ */}
         <section>
@@ -256,6 +263,8 @@ export default function GuidePage() {
             </div>
           )}
         </section>
+
+        {midBannerCta ? <AffiliateCTA {...midBannerCta} /> : null}
 
         {/* ═══════════ PHASE 2: Set Up Your Workspace ═══════════ */}
         <section>
@@ -561,6 +570,8 @@ List each finding with the file, line, severity, and a one-line fix.`} language=
             ))}
           </div>
         </section>
+
+        {endCardCta ? <AffiliateCTA {...endCardCta} /> : null}
       </main>
 
       {/* Spacer for HomeLayout footer */}

--- a/src/app/docs/[[...slug]]/page.tsx
+++ b/src/app/docs/[[...slug]]/page.tsx
@@ -49,8 +49,10 @@ export default async function Page(props: PageProps) {
       <DocsTitle>{data.title}</DocsTitle>
       <DocsDescription>{data.description}</DocsDescription>
       <DocsBody>
-        {isComparisonPage && hasComparisonMetadata ? (
-          <section className="mb-6 rounded-xl border border-fd-border bg-fd-card/50 px-4 py-4 sm:px-5">
+        {process.env.NODE_ENV === 'development' &&
+        isComparisonPage &&
+        hasComparisonMetadata ? (
+          <section className="mb-6 rounded-xl border border-dashed border-fd-border bg-fd-card/50 px-4 py-4 sm:px-5">
             {comparisonMetadata.targetKeyword ? (
               <p className="text-sm text-fd-muted-foreground">
                 <span className="font-medium text-fd-foreground">

--- a/src/app/docs/[[...slug]]/page.tsx
+++ b/src/app/docs/[[...slug]]/page.tsx
@@ -9,6 +9,8 @@ import { notFound } from 'next/navigation';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import { DemoCard } from '@/components/demo-card';
 import { EmailCapture } from '@/components/email-capture';
+import { AffiliateCTA } from '@/components/affiliate-cta';
+import { getAffiliateCtasForPage } from '@/lib/affiliate-cta-config';
 import type { Metadata } from 'next';
 
 const mdxComponents = {
@@ -28,13 +30,33 @@ export default async function Page(props: PageProps) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- fumadocs lazy-loads body/toc at runtime
   const data = page.data as any;
   const MDX = data.body;
+  const pageSlug = params.slug?.length ? `docs/${params.slug.join('/')}` : 'docs';
+  const ctas = getAffiliateCtasForPage(pageSlug);
+  const inlineCta = ctas.find((cta) => cta.placement === 'inline');
+  const midBannerCta = ctas.find((cta) => cta.placement === 'mid-banner');
+  const endCardCta = ctas.find((cta) => cta.placement === 'end-card');
 
   return (
     <DocsPage toc={data.toc} full={data.full}>
       <DocsTitle>{data.title}</DocsTitle>
       <DocsDescription>{data.description}</DocsDescription>
       <DocsBody>
+        {inlineCta ? (
+          <div className="mb-6">
+            <AffiliateCTA {...inlineCta} />
+          </div>
+        ) : null}
         <MDX components={mdxComponents} />
+        {midBannerCta ? (
+          <div className="mt-10">
+            <AffiliateCTA {...midBannerCta} />
+          </div>
+        ) : null}
+        {endCardCta ? (
+          <div className="mt-8">
+            <AffiliateCTA {...endCardCta} />
+          </div>
+        ) : null}
         <div className="mt-16 border-t border-fd-border pt-8">
           <EmailCapture />
         </div>

--- a/src/app/docs/[[...slug]]/page.tsx
+++ b/src/app/docs/[[...slug]]/page.tsx
@@ -10,7 +10,9 @@ import defaultMdxComponents from 'fumadocs-ui/mdx';
 import { DemoCard } from '@/components/demo-card';
 import { EmailCapture } from '@/components/email-capture';
 import { AffiliateCTA } from '@/components/affiliate-cta';
+import { ComparisonRelatedLinks } from '@/components/comparison-related-links';
 import { getAffiliateCtasForPage } from '@/lib/affiliate-cta-config';
+import { getComparisonArticleMetadata } from '@/lib/comparison-article';
 import type { Metadata } from 'next';
 
 const mdxComponents = {
@@ -35,15 +37,49 @@ export default async function Page(props: PageProps) {
   const inlineCta = ctas.find((cta) => cta.placement === 'inline');
   const midBannerCta = ctas.find((cta) => cta.placement === 'mid-banner');
   const endCardCta = ctas.find((cta) => cta.placement === 'end-card');
+  const comparisonMetadata = getComparisonArticleMetadata(data);
+  const isComparisonPage = pageSlug.startsWith('docs/comparisons/');
+  const hasComparisonMetadata =
+    Boolean(comparisonMetadata.targetKeyword) ||
+    comparisonMetadata.comparisonEntities.length > 0;
+  const hasRelatedLinks = comparisonMetadata.relatedLinks.length > 0;
 
   return (
     <DocsPage toc={data.toc} full={data.full}>
       <DocsTitle>{data.title}</DocsTitle>
       <DocsDescription>{data.description}</DocsDescription>
       <DocsBody>
+        {isComparisonPage && hasComparisonMetadata ? (
+          <section className="mb-6 rounded-xl border border-fd-border bg-fd-card/50 px-4 py-4 sm:px-5">
+            {comparisonMetadata.targetKeyword ? (
+              <p className="text-sm text-fd-muted-foreground">
+                <span className="font-medium text-fd-foreground">
+                  Target keyword:
+                </span>{' '}
+                {comparisonMetadata.targetKeyword}
+              </p>
+            ) : null}
+            {comparisonMetadata.comparisonEntities.length > 0 ? (
+              <p className="mt-2 text-sm text-fd-muted-foreground">
+                <span className="font-medium text-fd-foreground">
+                  Comparison entities:
+                </span>{' '}
+                {comparisonMetadata.comparisonEntities.join(' vs ')}
+              </p>
+            ) : null}
+          </section>
+        ) : null}
         {inlineCta ? (
           <div className="mb-6">
             <AffiliateCTA {...inlineCta} />
+          </div>
+        ) : null}
+        {isComparisonPage && hasRelatedLinks ? (
+          <div className="mb-8">
+            <ComparisonRelatedLinks
+              title="Related Guides Near This Intro"
+              links={comparisonMetadata.relatedLinks}
+            />
           </div>
         ) : null}
         <MDX components={mdxComponents} />
@@ -55,6 +91,14 @@ export default async function Page(props: PageProps) {
         {endCardCta ? (
           <div className="mt-8">
             <AffiliateCTA {...endCardCta} />
+          </div>
+        ) : null}
+        {isComparisonPage && hasRelatedLinks ? (
+          <div className="mt-10">
+            <ComparisonRelatedLinks
+              title="Continue Your Comparison Research"
+              links={comparisonMetadata.relatedLinks}
+            />
           </div>
         ) : null}
         <div className="mt-16 border-t border-fd-border pt-8">

--- a/src/components/affiliate-cta.tsx
+++ b/src/components/affiliate-cta.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useEffect, useMemo, useRef } from 'react';
+import { track } from '@vercel/analytics';
+import { ArrowRight } from 'lucide-react';
+
+export type AffiliateCTAPlacement = 'inline' | 'mid-banner' | 'end-card';
+
+interface AffiliateCTAProps {
+  pageSlug: string;
+  variantId: string;
+  placement: AffiliateCTAPlacement;
+  title: string;
+  description: string;
+  ctaLabel: string;
+  destination: string;
+}
+
+function normalizeEventPayload({
+  pageSlug,
+  variantId,
+  placement,
+  destination,
+}: Pick<AffiliateCTAProps, 'pageSlug' | 'variantId' | 'placement' | 'destination'>) {
+  return {
+    pageSlug,
+    ctaVariantId: variantId,
+    placement,
+    destination,
+  };
+}
+
+export function AffiliateCTA(props: AffiliateCTAProps) {
+  const sectionRef = useRef<HTMLElement | null>(null);
+  const hasTrackedView = useRef(false);
+  const payload = useMemo(
+    () =>
+      normalizeEventPayload({
+        pageSlug: props.pageSlug,
+        variantId: props.variantId,
+        placement: props.placement,
+        destination: props.destination,
+      }),
+    [props.pageSlug, props.variantId, props.placement, props.destination],
+  );
+
+  useEffect(() => {
+    const element = sectionRef.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting && !hasTrackedView.current) {
+            hasTrackedView.current = true;
+            track('affiliate_cta_view', payload);
+          }
+        });
+      },
+      { threshold: 0.35 },
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [payload]);
+
+  const onClick = () => {
+    track('affiliate_cta_click', payload);
+  };
+
+  const isExternal = /^https?:\/\//.test(props.destination);
+
+  const containerClassName =
+    props.placement === 'inline'
+      ? 'rounded-xl border border-emerald-500/25 bg-emerald-500/8 px-4 py-4 sm:px-5'
+      : props.placement === 'mid-banner'
+        ? 'rounded-2xl border border-indigo-500/25 bg-indigo-500/10 px-5 py-5 sm:px-6'
+        : 'rounded-2xl border border-fd-border bg-fd-card px-5 py-6 sm:px-6';
+
+  const descriptionClassName =
+    props.placement === 'mid-banner'
+      ? 'text-sm leading-relaxed text-fd-foreground/85'
+      : 'text-sm leading-relaxed text-fd-muted-foreground';
+
+  return (
+    <section ref={sectionRef} className={containerClassName}>
+      <p className="font-display text-lg font-normal tracking-tight text-fd-foreground">
+        {props.title}
+      </p>
+      <p className={`mt-2 ${descriptionClassName}`}>{props.description}</p>
+      <a
+        href={props.destination}
+        onClick={onClick}
+        className="mt-4 inline-flex items-center gap-2 rounded-lg bg-fd-primary px-4 py-2 text-sm font-medium text-fd-primary-foreground transition-opacity hover:opacity-90"
+        target={isExternal ? '_blank' : undefined}
+        rel={isExternal ? 'noopener noreferrer' : undefined}
+      >
+        {props.ctaLabel}
+        <ArrowRight className="h-4 w-4" />
+      </a>
+    </section>
+  );
+}

--- a/src/components/comparison-related-links.tsx
+++ b/src/components/comparison-related-links.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import type { ComparisonRelatedLink } from '@/lib/comparison-article';
+
+interface ComparisonRelatedLinksProps {
+  title: string;
+  links: ComparisonRelatedLink[];
+}
+
+export function ComparisonRelatedLinks({
+  title,
+  links,
+}: ComparisonRelatedLinksProps) {
+  if (!links.length) return null;
+
+  return (
+    <aside className="rounded-2xl border border-fd-border bg-fd-card/60 p-5 sm:p-6">
+      <h2 className="font-display text-xl font-medium tracking-tight text-fd-foreground">
+        {title}
+      </h2>
+      <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+        {links.map((link) => (
+          <li key={`${link.href}-${link.title}`} className="rounded-xl border border-fd-border bg-fd-background p-4">
+            <Link
+              href={link.href}
+              className="font-medium text-fd-foreground underline decoration-fd-border underline-offset-4 transition-colors hover:text-fd-primary"
+            >
+              {link.title}
+            </Link>
+            {link.description ? (
+              <p className="mt-2 text-sm leading-relaxed text-fd-muted-foreground">
+                {link.description}
+              </p>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/src/lib/affiliate-cta-config.ts
+++ b/src/lib/affiliate-cta-config.ts
@@ -1,0 +1,140 @@
+import type { AffiliateCTAPlacement } from '@/components/affiliate-cta';
+
+export interface AffiliateCTAConfig {
+  pageSlug: string;
+  variantId: string;
+  placement: AffiliateCTAPlacement;
+  title: string;
+  description: string;
+  ctaLabel: string;
+  destination: string;
+}
+
+type CTAConfigDraft = Omit<AffiliateCTAConfig, 'pageSlug' | 'variantId' | 'placement'>;
+
+const CTA_PLACEMENTS: AffiliateCTAPlacement[] = ['inline', 'mid-banner', 'end-card'];
+const DEFAULT_DESTINATION = 'https://claude.ai/upgrade';
+
+const guideDrafts: Record<AffiliateCTAPlacement, CTAConfigDraft> = {
+  inline: {
+    title: 'Pick your Claude plan before you keep building',
+    description:
+      'Start with Pro for guided practice, then upgrade when your daily usage grows. Keep momentum without paying for unused capacity.',
+    ctaLabel: 'Compare Pro vs Max',
+    destination: '/docs/comparisons/pro-vs-max',
+  },
+  'mid-banner': {
+    title: 'Ready for real projects?',
+    description:
+      'Use the same setup with your own repo. Claude plan limits affect throughput once you move from tutorials to production work.',
+    ctaLabel: 'See pricing and limits',
+    destination: DEFAULT_DESTINATION,
+  },
+  'end-card': {
+    title: 'Keep shipping: choose the plan that matches your workload',
+    description:
+      'Use our side-by-side comparison to pick the lowest-cost plan that still supports your daily coding and review flow.',
+    ctaLabel: 'Open plan comparison',
+    destination: '/docs/comparisons/pro-vs-max',
+  },
+};
+
+const comparisonDefaultDrafts: Record<AffiliateCTAPlacement, CTAConfigDraft> = {
+  inline: {
+    title: 'Compare options, then choose the right plan',
+    description:
+      'If Claude Code is your pick, validate plan limits and pricing before rollout so you do not hit avoidable bottlenecks later.',
+    ctaLabel: 'View Claude plan breakdown',
+    destination: '/docs/comparisons/pro-vs-max',
+  },
+  'mid-banner': {
+    title: 'Decision shortcut: pricing + limits in one place',
+    description:
+      'Use this before committing team workflows. You get clear differences on usage ceilings, context, and expected cost.',
+    ctaLabel: 'Review pricing details',
+    destination: DEFAULT_DESTINATION,
+  },
+  'end-card': {
+    title: 'Choose with confidence',
+    description:
+      'Open the final plan guide to match tool choice with budget, team size, and expected coding volume.',
+    ctaLabel: 'Open buyer guide',
+    destination: '/docs/comparisons/pro-vs-max',
+  },
+};
+
+const comparisonOverrides: Record<
+  string,
+  Partial<Record<AffiliateCTAPlacement, Partial<CTAConfigDraft>>>
+> = {
+  'docs/comparisons/vs-cursor': {
+    inline: {
+      title: 'Cursor vs Claude settled?',
+      description: 'Use the plan matrix next so you can estimate monthly cost before switching your default stack.',
+      ctaLabel: 'See Claude plan matrix',
+    },
+  },
+  'docs/comparisons/vs-copilot': {
+    inline: {
+      title: 'Copilot comparison done?',
+      description: 'Validate Claude plan limits and upgrade thresholds before migrating team usage.',
+      ctaLabel: 'Compare Claude plan limits',
+    },
+  },
+  'docs/comparisons/vs-codex': {
+    inline: {
+      title: 'Choosing between Codex and Claude Code?',
+      description:
+        'Lock in the right Claude tier first so budget and throughput remain predictable after migration.',
+      ctaLabel: 'Check Claude tiers',
+    },
+  },
+};
+
+function normalizeSlug(input: string): string {
+  return input.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+}
+
+function createConfig(
+  pageSlug: string,
+  placement: AffiliateCTAPlacement,
+  draft: CTAConfigDraft,
+): AffiliateCTAConfig {
+  return {
+    pageSlug,
+    placement,
+    variantId: `${normalizeSlug(pageSlug)}-${placement}`,
+    ...draft,
+  };
+}
+
+function resolveComparisonDraft(
+  pageSlug: string,
+  placement: AffiliateCTAPlacement,
+): CTAConfigDraft {
+  const defaultDraft = comparisonDefaultDrafts[placement];
+  const override = comparisonOverrides[pageSlug]?.[placement];
+
+  if (!override) return defaultDraft;
+
+  return {
+    ...defaultDraft,
+    ...override,
+  };
+}
+
+export function getAffiliateCtasForPage(pageSlug: string): AffiliateCTAConfig[] {
+  if (pageSlug === 'guide') {
+    return CTA_PLACEMENTS.map((placement) =>
+      createConfig(pageSlug, placement, guideDrafts[placement]),
+    );
+  }
+
+  if (!pageSlug.startsWith('docs/comparisons/')) {
+    return [];
+  }
+
+  return CTA_PLACEMENTS.map((placement) =>
+    createConfig(pageSlug, placement, resolveComparisonDraft(pageSlug, placement)),
+  );
+}

--- a/src/lib/comparison-article.ts
+++ b/src/lib/comparison-article.ts
@@ -1,0 +1,72 @@
+export interface ComparisonRelatedLink {
+  title: string;
+  href: string;
+  description?: string;
+}
+
+export interface ComparisonArticleMetadata {
+  targetKeyword?: string;
+  comparisonEntities: string[];
+  relatedLinks: ComparisonRelatedLink[];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function toStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function toRelatedLinks(value: unknown): ComparisonRelatedLink[] {
+  if (!Array.isArray(value)) return [];
+
+  const links: ComparisonRelatedLink[] = [];
+
+  for (const item of value) {
+    const record = asRecord(item);
+    if (!record) continue;
+
+    const title = typeof record.title === 'string' ? record.title.trim() : '';
+    const href = typeof record.href === 'string' ? record.href.trim() : '';
+    const description =
+      typeof record.description === 'string' ? record.description.trim() : undefined;
+
+    if (!title || !href || !href.startsWith('/')) continue;
+
+    links.push({
+      title,
+      href,
+      description: description || undefined,
+    });
+  }
+
+  return links;
+}
+
+export function getComparisonArticleMetadata(rawData: unknown): ComparisonArticleMetadata {
+  const data = asRecord(rawData);
+  if (!data) {
+    return {
+      comparisonEntities: [],
+      relatedLinks: [],
+    };
+  }
+
+  const targetKeyword =
+    typeof data.targetKeyword === 'string' && data.targetKeyword.trim().length > 0
+      ? data.targetKeyword.trim()
+      : undefined;
+
+  return {
+    targetKeyword,
+    comparisonEntities: toStringList(data.comparisonEntities),
+    relatedLinks: toRelatedLinks(data.relatedLinks),
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable affiliate CTA component that supports `inline`, `mid-banner`, and `end-card` patterns
- track CTA view and click events with payload fields `pageSlug`, `ctaVariantId`, `placement`, and `destination`
- wire CTA placements into `/guide` and `/docs/comparisons/*` templates
- add per-page CTA copy/config support with overrides for key comparison pages

## Validation
- `./node_modules/.bin/tsc --noEmit` (pass)
- `npm run build` currently hangs in this local environment due an existing Next build lock race; process was terminated and type-check completed cleanly.

## Context
- Task: MOO-6
